### PR TITLE
feat(cexPrices): add service to request and cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "apicache": "^1.6.2",
     "axios": "^0.24.0",
     "bignumber.js": "^9.0.1",
+    "binance-api-node": "^0.11.40",
     "body-parser": "^1.19.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ import farm from "./routes/farm";
 import userInfo from "./routes/user";
 import txList from "./routes/txList";
 import tokenPrice from "./routes/tokenPrice";
+import cexPrices from "./routes/cexPrices";
 
 // guaranteed to get dependencies
 export default () => {
@@ -23,6 +24,7 @@ export default () => {
   userInfo(app);
   txList(app);
   tokenPrice(app);
+  cexPrices(app);
 
   return app;
 };

--- a/src/api/routes/cexPrices.ts
+++ b/src/api/routes/cexPrices.ts
@@ -1,0 +1,78 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { Container } from "typedi";
+import { Logger } from "winston";
+import Binance from "binance-api-node";
+
+const route = Router();
+
+const client = Binance();
+const formatOHLC = datas => {
+    if (!Array.isArray(datas))
+        datas = [datas]
+    return datas.map(data => ({
+        time: (data.openTime || data.startTime) / 1000,
+        open: data.open,
+        high: data.high,
+        low: data.low,
+        close: data.close
+    }))
+}
+
+// CACHING
+const cache = {}
+const intervalMapping = {
+    "1m": 60, 
+    "5m": 60 * 5,
+    "15m": 60 * 15,
+    "1h": 60 * 60,
+    "4h": 60 * 60 * 4,
+    "1d": 60 * 60 * 24,
+    "1w": 60 * 60 * 24 * 7
+  };
+const interval2Sec = interval => {
+    return intervalMapping[interval];
+}
+//
+
+export default (app: Router) => {
+    // route prefix
+    app.use("/cexPrices", route);
+
+    const logger: Logger = Container.get("logger");
+
+    route.get(
+        "/binanceHistoricalPrice",
+        async (req: Request, res: Response, next: NextFunction) => {
+            logger.debug(
+                "Calling chart GET endpoint /add with query: %o",
+                req.query
+            );
+            try {
+                const {symbol, interval} = req.query;
+                const now = Date.now()
+                const cacheKey = `binance:${symbol}:${interval}`
+                // check data availability in cache
+                if (cache[cacheKey] && now / 1000 < cache[cacheKey].lastCandleTime + interval2Sec(interval)) {
+                    return res.status(201).json(cache[cacheKey].data);
+                }
+
+                let prevData = await client.candles({
+                    symbol,
+                    interval,
+                    limit: 1000,
+                    endTime: now
+                })
+                prevData = formatOHLC(prevData)
+                cache[cacheKey] = {
+                    lastCandleTime: prevData[prevData.length-1].openTime,
+                    data: prevData
+                }
+                // console.log("cache keys: ", Object.keys(cache));
+                return res.status(201).json(prevData);
+            } catch (e) {
+                logger.error("🔥 error: %o", e);
+                return next(e);
+            }
+        }
+    );
+};


### PR DESCRIPTION
这个更新是前端请求币安蜡烛图数据的代理API。
结构比较简单：
cache 结构如下
```
// <symbol>: 目前只有BTC, ETH, BNB, MATIC
// <interval>: 1m, 5m, 15m,1h, 4h, 1d, 7w

{ binance:<symbol>:<interval>: {
    lastCandleTime: 时间戳,
    data: OHLC数据
  },
  ...
}
```
API只有一个，若有cache则直接返回。否则获取后保存到cache里。

